### PR TITLE
Entry Challenge & Fix at systemctl-start-linux

### DIFF
--- a/src/members/anurag.md
+++ b/src/members/anurag.md
@@ -1,0 +1,7 @@
+---
+tags: outer_members
+name: Anurag Rao
+github: https://github.com/anuragrao04
+email: mailto:raoanu2004@gmail.com
+instagram: https://www.instagram.com/_anuragrao_/
+---

--- a/src/posts/systemctl start linux.md
+++ b/src/posts/systemctl start linux.md
@@ -164,11 +164,11 @@ Change directory using relative paths
 ```bash 
 $ cd ./path/to/some/folder/from/pwd 
 ```
-Installing FZF 
-```bash 
-$ git clone https:github.com/junegunn/fzf.git ~/.fzf
+Installing FZF
+```bash
+$ git clone https://github.com/junegunn/fzf.git ~/.fzf
 $ cd ~/.fzf 
-$ ./isntall 
+$ ./install 
 ```
 
 ### mkdir


### PR DESCRIPTION
This PR fixes a url error in the systemctl-start-linux post. The commands for installing FZF were broken. I have also added my name to the members section as a part of challenge-2 of the joining process. 

Note: A similar PR was opened before but had conflicts with the yarn.lock file because it was updated in the main repo. Have reforked it and opened a new one. Please review