### PR TITLE
Add blog post: RISC-V — The Linux of Hardware

### DIFF
--- a/src/posts/risc-v-intro.md
+++ b/src/posts/risc-v-intro.md
@@ -1,0 +1,69 @@
+---
+title: "RISC-V: The Linux of Hardware"
+date: "2025-09-06"
+tags: [tech, RISC-V] 
+description: "An article to get bootstrapped into learning things and building youself as a developer"
+permalink: posts/{{ title | slug }}/index.html
+author_name: M Pranav 
+author_link: "https://github.com/pranav0x0112"
+---
+
+## At Homebrew, we talk a lot about Linux and FOSS software. But what if I told you there’s a Linux moment happening in hardware too?
+
+## The Hidden Half of Computing
+
+Most of us discover [FOSS](https://homebrew.hsp-ec.xyz/posts/the-world-of-open-source!/) through software: cool Linux distros, editors, frameworks and many other tools that make our life easier. But beneath all that is a world not many of us think about: the microchips that run our code. All this while, this world was locked away behind billion-dollar corporations and closed [Instruction Set Architectures](https://en.wikipedia.org/wiki/Instruction_set_architecture).
+
+Say hello to [RISC-V (Reduced Instruction Set Computer)](https://en.wikipedia.org/wiki/RISC-V) — an open source Instruction Set Architecture(ISA) that’s doing to hardware what Linux did to operating systems. This blog is a quick introduction to what RISC-V is, why it matters, and how it fits perfectly into the FOSS spirit.
+
+## So What’s an ISA anyway?
+
+We all speak different languages with our own unique grammar. Similarly, a processor has its own “grammar” called an **Instruction Set Architecture (ISA)** — the rules that define how software talks to hardware.
+
+When you think “processor,” names like Intel’s x86 or AMD’s Ryzen probably come to mind. Maybe you’ve even heard of ARM chips in mobile phones and Raspberry Pi. But here’s the catch: all of these are **proprietary**. That means if you want to design a chip with them, you’ll need to pay hefty license fees, sign NDAs, and basically fight uphill just to get started.
+
+Back in 2010, researchers at [UC Berkeley](https://www.sifive.com/blog/from-berkeley-lab-to-global-standard-risc-vs-15-ye) decided to change that. Their project: RISC-V — an open source, free and modular ISA. This means anyone can use it, extend it and guess what even add their own instructions! The entire script was flipped, making hardware innovation as open as software innovation.
+
+![RISC-V Logo](https://i.postimg.cc/dkTKKkY4/RISC-V-logo-1.png)
+
+## Why should students care about RISC-V?
+
+### **1. FOSS energy → The same spirit as Linux**
+
+The openness of RISC-V has created ecosystems much like Linux did — thriving communities, student-led projects, multiple open-source processor cores, Discord servers buzzing with discussions, and more. It’s not just an ISA; it’s a culture you can join and shape.
+
+### **2. A real learning playground → No glass walls**
+
+Hardware design often feels like wizardry happening in corporate or research labs. But RISC-V opens the doors for everyone. Curious about how a processor works internally? You can:
+
+1. Browse and study real RISC-V cores on GitHub: from tiny educational cores to ones capable of running Linux.
+
+2. Simulate a RISC-V CPU using open-source tools like [QEMU](https://en.wikipedia.org/wiki/QEMU).
+
+![Ripes Simulation](https://i.postimg.cc/Vk4z3jmS/animation.gif)
+
+> **Peek inside a RISC-V CPU: one instruction at a time, courtesy of** [**Ripes**](https://github.com/mortbopet/Ripes)**.** You’re not stuck just reading theory; you can **play with the real thing**.
+
+### **3. Structured guidance → Mentorship and learning programs**
+
+RISC-V isn’t just open; it’s supportive. The [RISC-V Foundation](https://riscv.org/) hosts mentorship programs, student contests, workshops, and provides online resources. Beginners can pair up with experienced developers, contribute to real cores, and learn in a guided environment which makes the learning curve far less intimidating.
+
+### **4. Industry shift → Where the world is heading**
+
+This isn’t just about tinkering. RISC-V is becoming a global standard. Tech giants like Intel, NVIDIA, Google, and Qualcomm are adopting it. That means demand for engineers who understand RISC-V is going to rise. As students, learning it now is like learning Linux in the early 2000s: the skills are future-proof.
+
+## Why RISC-V Resonates with me?
+
+My first introduction to RISC-V was at [Tilde](https://hsp-ec.xyz/announcements/tilde-4.0), HSP’s flagship summer mentorship program where we were tasked with building a RISC processor in [Verilog](https://en.wikipedia.org/wiki/Verilog). Although I wasn’t able to continue with the project, I was given access to vast resources that opened the door to the world of RISC. I started out with simple [Linux Foundation courses](https://training.linuxfoundation.org/training/introduction-to-riscv-lfd110/) and quickly found myself immersed in the subject, having already delved deep into Digital VLSI.
+
+Soon, I was diving into books and research papers to understand the architecture and design principles of RISC-V. At the same time, I was building [**RISCape**](https://github.com/pranav0x0112/RISCape), a 5-stage pipelined RISC-V processor. Reading the theory while implementing it side by side made the concepts click in a way no textbook alone could achieve.
+
+This hands-on approach showed me the real power of open architectures: students can explore, experiment, and actually **make things work**, all without asking for permission. If it got me hooked, it can probably do the same for you: grab a core, start experimenting, and see where it takes you.
+
+![RISC-V Processor Block Diagram](https://i.postimg.cc/MG81FJZZ/risc-v-processor-block-diagram.png)
+
+## Closing Thoughts
+
+RISC-V is more than just a processor architecture: it’s an open, collaborative ecosystem that mirrors the FOSS philosophy we see in software. From student-friendly cores to real-world applications, it’s shaping the way hardware can be explored, understood, and innovated upon.
+
+In the next post, we’ll dive into the tools and resources that make experimenting with hardware easier. From simulators to development frameworks and see how you can start building your own projects from scratch.

--- a/src/posts/risc-v-intro.md
+++ b/src/posts/risc-v-intro.md
@@ -2,7 +2,7 @@
 title: "RISC-V: The Linux of Hardware"
 date: "2025-09-07"
 tags: [tech, RISC-V] 
-description: "An article to get bootstrapped into learning things and building youself as a developer"
+description: "Explore RISC-V, the open hardware movement making processor design accessible to students, developers, and researchers alike."
 permalink: posts/{{ title | slug }}/index.html
 author_name: M Pranav 
 author_link: "https://github.com/pranav0x0112"
@@ -36,13 +36,13 @@ The openness of RISC-V has created ecosystems much like Linux did — thriving c
 
 Hardware design often feels like wizardry happening in corporate or research labs. But RISC-V opens the doors for everyone. Curious about how a processor works internally? You can:
 
-1. Browse and study real RISC-V cores on GitHub: from tiny educational cores to ones capable of running Linux.
-
-2. Simulate a RISC-V CPU using open-source tools like [QEMU](https://en.wikipedia.org/wiki/QEMU).
+- Browse and study real RISC-V cores on GitHub: from tiny educational cores to ones capable of running Linux.
+- Simulate a RISC-V CPU using open-source tools like [QEMU](https://en.wikipedia.org/wiki/QEMU).
 
 ![Ripes Simulation](https://i.postimg.cc/Vk4z3jmS/animation.gif)
 
-> **Peek inside a RISC-V CPU: one instruction at a time, courtesy of** [**Ripes**](https://github.com/mortbopet/Ripes)**.** You’re not stuck just reading theory; you can **play with the real thing**.
+> **Peek inside a RISC-V CPU: one instruction at a time, courtesy of [Ripes](https://github.com/mortbopet/Ripes).**  
+> Ripes is a visual simulator for computer architecture, with an integrated assembly code editor, built for the RISC-V instruction set architecture. You’re not stuck just reading theory; you can play with the real thing.
 
 ### **3. Structured guidance → Mentorship and learning programs**
 

--- a/src/posts/risc-v-intro.md
+++ b/src/posts/risc-v-intro.md
@@ -1,6 +1,6 @@
 ---
 title: "RISC-V: The Linux of Hardware"
-date: "2025-09-06"
+date: "2025-09-07"
 tags: [tech, RISC-V] 
 description: "An article to get bootstrapped into learning things and building youself as a developer"
 permalink: posts/{{ title | slug }}/index.html
@@ -14,7 +14,7 @@ author_link: "https://github.com/pranav0x0112"
 
 Most of us discover [FOSS](https://homebrew.hsp-ec.xyz/posts/the-world-of-open-source!/) through software: cool Linux distros, editors, frameworks and many other tools that make our life easier. But beneath all that is a world not many of us think about: the microchips that run our code. All this while, this world was locked away behind billion-dollar corporations and closed [Instruction Set Architectures](https://en.wikipedia.org/wiki/Instruction_set_architecture).
 
-Say hello to [RISC-V (Reduced Instruction Set Computer)](https://en.wikipedia.org/wiki/RISC-V) — an open source Instruction Set Architecture(ISA) that’s doing to hardware what Linux did to operating systems. This blog is a quick introduction to what RISC-V is, why it matters, and how it fits perfectly into the FOSS spirit.
+Say hello to [RISC-V (Reduced Instruction Set Computer)](https://en.wikipedia.org/wiki/RISC-V) — an open source Instruction Set Architecture (ISA) that’s doing to hardware what Linux did to operating systems. This blog is a quick introduction to what RISC-V is, why it matters, and how it fits perfectly into the FOSS spirit.
 
 ## So What’s an ISA anyway?
 


### PR DESCRIPTION
This PR adds a new blog post introducing RISC-V and its significance as an open hardware standard.  
Includes images and diagrams for better visualization.  